### PR TITLE
Add skeuomorphic queue interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Queue React App</title>
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "serve dist",
     "res:build": "rescript",
     "res:dev": "rescript build -w",
-    "build": "npm run res:build && mkdir -p dist && esbuild src/Index.mjs --bundle --format=esm --outfile=dist/app.js && cp index.html dist/index.html",
+    "build": "npm run res:build && mkdir -p dist && esbuild src/Index.mjs --bundle --format=esm --outfile=dist/app.js && cp index.html dist/index.html && cp style.css dist/style.css",
     "vercel-build": "npm run build"
   },
   "keywords": [],

--- a/src/Index.res
+++ b/src/Index.res
@@ -1,8 +1,24 @@
+open Util
+
+let window_ = Webapi.Dom.window
+let location = window_->Webapi.Dom.Window.location
+let path = location->Webapi.Dom.Location.pathname
+
+let segments = path->Js.String.split("/")->Belt.Array.keep(s => s != "")
+let storeId =
+  switch segments {
+  | [id] => id
+  | _ =>
+    let id = Util.randomUUID()
+    location->Webapi.Dom.Location.setPathname("/" ++ id)
+    id
+  }
+
 let rootEl =
   Webapi.Dom.document
   ->Webapi.Dom.Document.getElementById("root")
   ->Belt.Option.getExn
 
 let root = ReactDOM.Client.createRoot(rootEl)
-root->ReactDOM.Client.Root.render(<App />)
+root->ReactDOM.Client.Root.render(<StorePage storeId />)
 

--- a/src/StorePage.res
+++ b/src/StorePage.res
@@ -1,0 +1,40 @@
+open App
+open Util
+
+let ensureStoreExists = async storeId => {
+  let storeRef = App.gun->App.Gun.get(App.Constants.storesLabel)->App.Gun.get(storeId)
+  // Put a placeholder to ensure the store exists
+  await storeRef->App.Gun.put({"created": Js.Date.make()->Js.Date.toISOString})
+}
+
+@react.component
+let make = (~storeId: string) => {
+  let (ticketId, setTicketId) = React.useState(() => "")
+
+  React.useEffect0(() => {
+    ensureStoreExists(storeId)->ignore
+    None
+  });
+
+  let takeNumber = _ =>
+    Js.Promise.then_(
+      id => {
+        setTicketId(_ => id)
+        Js.Promise.resolve()
+      },
+      App.enterQueue("Customer", storeId),
+    )
+    |> ignore
+
+  <div className="store-page">
+    <h2>{React.string("Take a Number")}</h2>
+    <div className="dispenser" draggable=true onDragEnd={_ => takeNumber()}>
+      <div className="ticket" />
+    </div>
+    {switch ticketId {
+    | "" => React.null
+    | id => <p className="ticket-display">{React.string("Ticket ID: " ++ id)}</p>
+    }}
+  </div>
+}
+

--- a/src/Util.res
+++ b/src/Util.res
@@ -1,0 +1,1 @@
+@val external randomUUID: unit => string = "crypto.randomUUID"

--- a/style.css
+++ b/style.css
@@ -1,0 +1,34 @@
+.store-page {
+  text-align: center;
+  font-family: sans-serif;
+  margin-top: 40px;
+}
+
+.dispenser {
+  width: 160px;
+  height: 220px;
+  margin: 0 auto;
+  background: #cc0000;
+  border-radius: 8px;
+  box-shadow: inset 0 -6px 0 #990000, 0 4px 6px rgba(0,0,0,0.3);
+  position: relative;
+  cursor: grab;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.dispenser .ticket {
+  width: 120px;
+  height: 40px;
+  background: #fff;
+  border: 2px dashed #333;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+
+.ticket-display {
+  margin-top: 20px;
+  font-size: 1.2em;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- create StorePage with ticket dispenser
- redirect store URLs in Index
- copy style in build script
- add basic styles

## Testing
- `npm run res:build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859b949bd7c832d836dad71a5f31799